### PR TITLE
chore(ci): stabilize playwright e2e in github actions

### DIFF
--- a/.github/workflows/npm-build-branches.yml
+++ b/.github/workflows/npm-build-branches.yml
@@ -19,5 +19,6 @@ jobs:
       - run: npm ci
       - name: Install Playwright Browsers
         run: npx playwright install --with-deps
+      - run: npm run build
       - run: npm test
 

--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -31,6 +31,8 @@ jobs:
       - name: Install Playwright Browsers
         run: npx playwright install --with-deps
       - run: npm test
+        env:
+          DEBUG: pw:webserver
       - name: Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,9 +1,13 @@
 import { defineConfig } from '@playwright/test';
 
+declare const process: { env: Record<string, string | undefined> };
+
 export default defineConfig({
 	webServer: {
-		command: 'npm run build && npm run preview',
-		port: 4173
+		command: 'npm run preview',
+		port: 4173,
+		timeout: 120_000,
+		reuseExistingServer: !process.env.CI
 	},
 	testDir: 'e2e'
 });


### PR DESCRIPTION
The webServer block inlined `npm run build && npm run preview` under Playwright's default 60s timeout, so e2e runs hung or failed whenever the runner was cold enough to push the build past that window. Move the build into a dedicated workflow step, raise the webServer timeout to 120s, and keep preview reuse enabled for local runs. Enable pw:webserver debug output on the release workflow to diagnose any residual hangs on main.